### PR TITLE
style: 日本語を直し、平仄を合わせた。

### DIFF
--- a/life.spec.js
+++ b/life.spec.js
@@ -82,7 +82,7 @@ describe('次世代の判定ができること', () => {
   it('活性セルの周囲のセルが 1 なら、不活性であること', () => {
     expect(life.nextCell(true, 1)).toBe(false)
   })
-  it('周囲のセルが 3 なら、活性であること', () => {
+  it('不活性セルの周囲のセルが 3 なら、活性であること', () => {
     expect(life.nextCell(false, 3)).toBe(true)
   })
   it.todo('過密')

--- a/life.spec.js
+++ b/life.spec.js
@@ -73,16 +73,16 @@ describe('八近傍に活性通知のインクリメントができること', (
 })
 
 describe('次世代の判定ができること', () => {
-  it('不活性セルの周囲のセルが 2 なら、不活性活性であること', () => {
+  it('不活性セルの周囲のセルが 2 なら、不活性であること', () => {
     expect(life.nextCell(false, 2)).toBe(false)
   })
   it('活性セルの周囲のセルが 2 なら、活性であること', () => {
     expect(life.nextCell(true, 2)).toBe(true)
   })
-  it('活性セルの周囲のセルが一つなら、不活性であること', () => {
+  it('活性セルの周囲のセルが 1 なら、不活性であること', () => {
     expect(life.nextCell(true, 1)).toBe(false)
   })
-  it('周囲のセルが三つなら、活性であること', () => {
+  it('周囲のセルが 3 なら、活性であること', () => {
     expect(life.nextCell(false, 3)).toBe(true)
   })
   it.todo('過密')


### PR DESCRIPTION
日本語を直しました。
日本語の平仄を合わせることで、仕様として大事なところだけが際立って見落としが少なくなります。